### PR TITLE
Allow parent code path to be created if it doesn't exist.

### DIFF
--- a/make_ipynb.py
+++ b/make_ipynb.py
@@ -70,7 +70,7 @@ def make_code(chapter):
 
         # Output notebook path.
         output_dir = Path('code/%s/' % chapter)
-        output_dir.mkdir(exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
         path = (output_dir / file.name).with_suffix('.ipynb')
 
         # Export the AST into a Jupyter notebook.


### PR DESCRIPTION
When running make_ipynb.py for the first time, it fails because the `code` path does not exist.

This change allows the parent path to be created.